### PR TITLE
fix some Number and String parsing issues

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -232,7 +232,7 @@ where
                     }
                 }
                 Mode::Number => match c {
-                    b'0'...b'9' | b'-' | b'.' => {
+                    b'0'...b'9' | b'-' | b'+' | b'.' | b'E' | b'e' => {
                         if let Some(ref mut v) = buf {
                             v.push(c);
                         }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -157,8 +157,8 @@ where
 
 // Identifies the state of the lexer
 enum Mode {
-    // String parse mode: bool = ignore_next
-    String(bool),
+    // String parse mode: bool = ignore_next, usize = ignore_digits
+    String(bool, usize),
     // `null` parse mode: buf, buf-index
     Null([u8; 4], usize),
     // `true` parse mode
@@ -194,13 +194,38 @@ where
             };
 
             match state {
-                Mode::String(ref mut ign_next) => {
+                Mode::String(ref mut ign_next, ref mut ign_digits) => {
                     if let Some(ref mut v) = buf {
                         v.push(c);
                     }
-                    if *ign_next && (c == b'"' || c == b'\\') {
-                        *ign_next = false;
-                        continue;
+                    if *ign_next {
+                        match c {
+                            b'"' | b'\\' | b'/' | b'b' | b'f' | b'n' | b'r' | b't' => {
+                                *ign_next = false;
+                                continue;
+                            }
+                            b'u' => {
+                                *ign_next = false;
+                                *ign_digits = 4;
+                                continue;
+                            }
+                            _ => {
+                                t = Some(TokenType::Invalid);
+                                break;
+                            }
+                        }
+                    }
+                    if *ign_digits > 0 {
+                        match c {
+                            b'0'...b'9' | b'A'...b'F' | b'a'...b'f' => {
+                                *ign_digits -= 1;
+                                continue;
+                            }
+                            _ => {
+                                t = Some(TokenType::Invalid);
+                                break;
+                            }
+                        }
                     }
                     match c {
                         b'"' => {
@@ -287,7 +312,7 @@ where
                             break;
                         }
                         b'"' => {
-                            state = Mode::String(false);
+                            state = Mode::String(false, 0);
                             if let Some(ref mut v) = buf {
                                 v.push(c);
                             } else {

--- a/tests/lexer.rs
+++ b/tests/lexer.rs
@@ -123,6 +123,53 @@ fn backslash_escapes_backslash_in_string_value() {
 }
 
 #[test]
+fn other_backslash_escapes_in_string_value() {
+    let src = r#"{"s":"\/\b\f\n\r\t\u1a2B"}"#;
+    let mut it = Lexer::new(src.bytes(), BufferType::Span);
+
+    assert_eq!(
+        it.by_ref().skip(3).next(),
+        Some(Token {
+            kind: TokenType::String,
+            buf: Buffer::Span(Span { first: 5, end: 25 }),
+        })
+    );
+
+    let src = r#"{"s":"\a"}"#;
+    let mut it = Lexer::new(src.bytes(), BufferType::Span);
+
+    assert_eq!(
+        it.by_ref().skip(3).next(),
+        Some(Token {
+            kind: TokenType::Invalid,
+            buf: Buffer::Span(Span { first: 5, end: 8 }),
+        })
+    );
+
+    let src = r#"{"s":"\u123"}"#;
+    let mut it = Lexer::new(src.bytes(), BufferType::Span);
+
+    assert_eq!(
+        it.by_ref().skip(3).next(),
+        Some(Token {
+            kind: TokenType::Invalid,
+            buf: Buffer::Span(Span { first: 5, end: 12 }),
+        })
+    );
+
+    let src = r#"{"s":"\u123x"}"#;
+    let mut it = Lexer::new(src.bytes(), BufferType::Span);
+
+    assert_eq!(
+        it.by_ref().skip(3).next(),
+        Some(Token {
+            kind: TokenType::Invalid,
+            buf: Buffer::Span(Span { first: 5, end: 12 }),
+        })
+    );
+}
+
+#[test]
 fn special_values_closed_and_unclosed() {
     for &(src, ref kind, first, end) in &[
         (r#"{"v":null}"#, TokenType::Null, 5, 9),

--- a/tests/lexer.rs
+++ b/tests/lexer.rs
@@ -137,6 +137,12 @@ fn special_values_closed_and_unclosed() {
         (r#"{"v":-1.23}"#, TokenType::Number, 5, 10),
         (r#"{"v":1.}"#, TokenType::Number, 5, 7),
         (r#"{"v":.}"#, TokenType::Number, 5, 6),
+        (r#"{"v":1.23E12}"#, TokenType::Number, 5, 12),
+        (r#"{"v":1.23e12}"#, TokenType::Number, 5, 12),
+        (r#"{"v":1.23E+12}"#, TokenType::Number, 5, 13),
+        (r#"{"v":1.23e+12}"#, TokenType::Number, 5, 13),
+        (r#"{"v":1.23E-12}"#, TokenType::Number, 5, 13),
+        (r#"{"v":1.23e-12}"#, TokenType::Number, 5, 13),
     ] {
         assert_eq!(
             Lexer::new(src.bytes(), BufferType::Span).skip(3).next(),


### PR DESCRIPTION
This adds support for Number tokens with exponents and String tokens with the full range of escapes that are allowed.  (I didn't bother adding more error handling to Number, since it already accepts invalid tokens like `1-1`.)